### PR TITLE
self.target_sr was used before initializing

### DIFF
--- a/rest-api/src/inference.py
+++ b/rest-api/src/inference.py
@@ -33,8 +33,8 @@ class TextToSpeechEngine:
         self.enable_denoiser = enable_denoiser
         if enable_denoiser:
             from src.postprocessor import Denoiser
-            self.denoiser = Denoiser(self.orig_sr, self.target_sr)
             self.target_sr = 16000
+            self.denoiser = Denoiser(self.orig_sr, self.target_sr)
         else:
             self.target_sr = self.orig_sr
         


### PR DESCRIPTION
The "self.target_sr = 16000" was declared after it's called in the previous line.